### PR TITLE
switch from namespace::sweep to namespace::autoclean

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+
+        * switch back to the more-maintained namespace::autoclean.
+
 0.113   14.10.16
         * Provide a META.json file.
         * Removed some duplication in resources in metadata.

--- a/lib/MooseX/Role/Loggable.pm
+++ b/lib/MooseX/Role/Loggable.pm
@@ -11,7 +11,7 @@ use Moo::Role;
 use MooX::Types::MooseLike::Base qw<Bool Str>;
 use Sub::Quote 'quote_sub';
 use Log::Dispatchouli;
-use namespace::sweep;
+use namespace::autoclean;
 
 my %attr_meth_map = (
     'logger_facility' => 'facility',


### PR DESCRIPTION
namespace::sweep is now obsolete and namespace::autoclean handles more cases,
more properly. Anything using Moose, Moo or Mouse should absolutely be using
namespace::autoclean.

(0.16 is the version that dropped the loading of Class::MOP to introspect Moo classes.)